### PR TITLE
fix: A note about conventional commits.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,6 @@
 - Fork this repository
 - Make a change on `main` branch
 - For new urls please provide the "more stable" url of the project to add. E.g. for `npm` packages use the `https://www.npmjs.com` project path, for Drupal modules use the `https://www.drupal.org` projects path, for several tools use the `https://www.github.com` project path etc.
+- Consider using [conventional commit messages](https://www.conventionalcommits.org/).
 - Create a Pull Request on branch `main`
 - For discussions please use the [Project Issues](https://github.com/eworx-org/drupal-js/issues)


### PR DESCRIPTION
Suggest usage of https://www.conventionalcommits.org/ which is generally pretty useful.